### PR TITLE
Windows 11 ARM Installation Support

### DIFF
--- a/BuildAutoIncrement/source.extension.vsixmanifest
+++ b/BuildAutoIncrement/source.extension.vsixmanifest
@@ -14,14 +14,23 @@
     </Metadata>
     <Installation>
         <InstallationTarget Version="[17.0,18.0)" Id="Microsoft.VisualStudio.Pro">
-            <ProductArchitecture>amd64</ProductArchitecture>
+            <ProductArchitecture>arm64</ProductArchitecture>
         </InstallationTarget>
         <InstallationTarget Version="[17.0,18.0)" Id="Microsoft.VisualStudio.Enterprise">
-            <ProductArchitecture>amd64</ProductArchitecture>
+            <ProductArchitecture>arm64</ProductArchitecture>
         </InstallationTarget>
         <InstallationTarget Version="[17.0,18.0)" Id="Microsoft.VisualStudio.Community">
-            <ProductArchitecture>amd64</ProductArchitecture>
+            <ProductArchitecture>arm64</ProductArchitecture>
         </InstallationTarget>
+		<InstallationTarget Version="[17.0,18.0)" Id="Microsoft.VisualStudio.Pro">
+			<ProductArchitecture>amd64</ProductArchitecture>
+		</InstallationTarget>
+		<InstallationTarget Version="[17.0,18.0)" Id="Microsoft.VisualStudio.Enterprise">
+			<ProductArchitecture>amd64</ProductArchitecture>
+		</InstallationTarget>
+		<InstallationTarget Version="[17.0,18.0)" Id="Microsoft.VisualStudio.Community">
+			<ProductArchitecture>amd64</ProductArchitecture>
+		</InstallationTarget>
     </Installation>
     <Dependencies>
         <Dependency Id="Microsoft.Framework.NDP" DisplayName="Microsoft .NET Framework" d:Source="Manual" Version="[4.8,)" />

--- a/BuildAutoIncrement/source.extension.vsixmanifest
+++ b/BuildAutoIncrement/source.extension.vsixmanifest
@@ -13,24 +13,24 @@
         <Tags>Versioning, Versioning Manager, Version Control</Tags>
     </Metadata>
     <Installation>
+	<InstallationTarget Version="[17.0,18.0)" Id="Microsoft.VisualStudio.Pro">
+		<ProductArchitecture>amd64</ProductArchitecture>
+	</InstallationTarget>
+	<InstallationTarget Version="[17.0,18.0)" Id="Microsoft.VisualStudio.Enterprise">
+		<ProductArchitecture>amd64</ProductArchitecture>
+	</InstallationTarget>
+	<InstallationTarget Version="[17.0,18.0)" Id="Microsoft.VisualStudio.Community">
+		<ProductArchitecture>amd64</ProductArchitecture>
+	</InstallationTarget>
         <InstallationTarget Version="[17.0,18.0)" Id="Microsoft.VisualStudio.Pro">
-            <ProductArchitecture>arm64</ProductArchitecture>
+            	<ProductArchitecture>arm64</ProductArchitecture>
         </InstallationTarget>
         <InstallationTarget Version="[17.0,18.0)" Id="Microsoft.VisualStudio.Enterprise">
-            <ProductArchitecture>arm64</ProductArchitecture>
+            	<ProductArchitecture>arm64</ProductArchitecture>
         </InstallationTarget>
         <InstallationTarget Version="[17.0,18.0)" Id="Microsoft.VisualStudio.Community">
-            <ProductArchitecture>arm64</ProductArchitecture>
+            	<ProductArchitecture>arm64</ProductArchitecture>
         </InstallationTarget>
-		<InstallationTarget Version="[17.0,18.0)" Id="Microsoft.VisualStudio.Pro">
-			<ProductArchitecture>amd64</ProductArchitecture>
-		</InstallationTarget>
-		<InstallationTarget Version="[17.0,18.0)" Id="Microsoft.VisualStudio.Enterprise">
-			<ProductArchitecture>amd64</ProductArchitecture>
-		</InstallationTarget>
-		<InstallationTarget Version="[17.0,18.0)" Id="Microsoft.VisualStudio.Community">
-			<ProductArchitecture>amd64</ProductArchitecture>
-		</InstallationTarget>
     </Installation>
     <Dependencies>
         <Dependency Id="Microsoft.Framework.NDP" DisplayName="Microsoft .NET Framework" d:Source="Manual" Version="[4.8,)" />

--- a/BuildAutoIncrement/source.extension.vsixmanifest
+++ b/BuildAutoIncrement/source.extension.vsixmanifest
@@ -14,22 +14,22 @@
     </Metadata>
     <Installation>
 	<InstallationTarget Version="[17.0,18.0)" Id="Microsoft.VisualStudio.Pro">
-		<ProductArchitecture>amd64</ProductArchitecture>
+            <ProductArchitecture>amd64</ProductArchitecture>
 	</InstallationTarget>
 	<InstallationTarget Version="[17.0,18.0)" Id="Microsoft.VisualStudio.Enterprise">
-		<ProductArchitecture>amd64</ProductArchitecture>
+            <ProductArchitecture>amd64</ProductArchitecture>
 	</InstallationTarget>
 	<InstallationTarget Version="[17.0,18.0)" Id="Microsoft.VisualStudio.Community">
-		<ProductArchitecture>amd64</ProductArchitecture>
+            <ProductArchitecture>amd64</ProductArchitecture>
 	</InstallationTarget>
         <InstallationTarget Version="[17.0,18.0)" Id="Microsoft.VisualStudio.Pro">
-            	<ProductArchitecture>arm64</ProductArchitecture>
+            <ProductArchitecture>arm64</ProductArchitecture>
         </InstallationTarget>
         <InstallationTarget Version="[17.0,18.0)" Id="Microsoft.VisualStudio.Enterprise">
-            	<ProductArchitecture>arm64</ProductArchitecture>
+            <ProductArchitecture>arm64</ProductArchitecture>
         </InstallationTarget>
         <InstallationTarget Version="[17.0,18.0)" Id="Microsoft.VisualStudio.Community">
-            	<ProductArchitecture>arm64</ProductArchitecture>
+            <ProductArchitecture>arm64</ProductArchitecture>
         </InstallationTarget>
     </Installation>
     <Dependencies>


### PR DESCRIPTION
Updated InstallationTarget to include arm64 allowing this plugin to be installed on Windows 11 ARM /w Visual Studio 2022