### PR TITLE
Visual Studio 2022 ARM 64 Build Fix

### DIFF
--- a/BuildAutoIncrement/BuildAutoIncrement.csproj
+++ b/BuildAutoIncrement/BuildAutoIncrement.csproj
@@ -66,6 +66,8 @@
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <PreferNativeArm64>false</PreferNativeArm64>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
@@ -365,19 +367,19 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.VisualStudio.Imaging">
-      <Version>17.2.32505.113</Version>
+      <Version>17.12.40391</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.VisualStudio.SDK">
-      <Version>17.2.32505.173</Version>
+      <Version>17.12.40392</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.VisualStudio.Shell.Interop">
-      <Version>17.2.32505.113</Version>
+      <Version>17.12.40391</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.VisualStudio.Threading">
-      <Version>17.2.32</Version>
+      <Version>17.12.19</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.VSSDK.BuildTools">
-      <Version>17.2.2190</Version>
+      <Version>17.13.1094-preview2</Version>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/BuildAutoIncrement/source.extension.vsixmanifest
+++ b/BuildAutoIncrement/source.extension.vsixmanifest
@@ -13,15 +13,15 @@
         <Tags>Versioning, Versioning Manager, Version Control</Tags>
     </Metadata>
     <Installation>
-	<InstallationTarget Version="[17.0,18.0)" Id="Microsoft.VisualStudio.Pro">
+        <InstallationTarget Version="[17.0,18.0)" Id="Microsoft.VisualStudio.Pro">
             <ProductArchitecture>amd64</ProductArchitecture>
-	</InstallationTarget>
-	<InstallationTarget Version="[17.0,18.0)" Id="Microsoft.VisualStudio.Enterprise">
+        </InstallationTarget>
+        <InstallationTarget Version="[17.0,18.0)" Id="Microsoft.VisualStudio.Enterprise">
             <ProductArchitecture>amd64</ProductArchitecture>
-	</InstallationTarget>
-	<InstallationTarget Version="[17.0,18.0)" Id="Microsoft.VisualStudio.Community">
+        </InstallationTarget>
+        <InstallationTarget Version="[17.0,18.0)" Id="Microsoft.VisualStudio.Community">
             <ProductArchitecture>amd64</ProductArchitecture>
-	</InstallationTarget>
+        </InstallationTarget>
         <InstallationTarget Version="[17.0,18.0)" Id="Microsoft.VisualStudio.Pro">
             <ProductArchitecture>arm64</ProductArchitecture>
         </InstallationTarget>
@@ -43,3 +43,4 @@
         <Prerequisite Id="Microsoft.VisualStudio.Component.CoreEditor" Version="[17.0,18.0)" DisplayName="Visual Studio core editor" />
     </Prerequisites>
 </PackageManifest>
+


### PR DESCRIPTION
Resolves issue building on Windows 11 using Visual Studio 2022. The VSIX .net dependencies are out of date which causes a schema validation issue when trying to use the ProductTarget `arm64`. I pulled down the project and updated to NuGet references to the latest versions and presto! 

To validate this fix pull down the PR, build the solution using VS 2022 on Windows 11 ARM and the build should complete successfully. Then run the installation to confirm it hooks into VS 2022. 

Note that when I go to https://marketplace.visualstudio.com/items?itemName=NeeleGuido.VersioningControlledBuild2022 to install this extension it does not work and there is no mention that it does not with VS2022 on Windows 11 ARM. 